### PR TITLE
handle possible 'None' to avoid a crash

### DIFF
--- a/googledevices/utils/scan.py
+++ b/googledevices/utils/scan.py
@@ -22,11 +22,12 @@ class NetworkScan(object):
             googlewifi = WifiInfo(loop=self.loop, session=session)
             await googlewifi.get_wifi_info()
         if googlewifi.wifi_host is not None:
+            w = googlewifi.wifi_info
             wifi = {
                 "assistant": False,
                 "bluetooth": False,
                 "host": googlewifi.wifi_host,
-                "model": googlewifi.wifi_info.get("system", {}).get("modelId"),
+                "model": "None" if w is None else w.get("system", {}).get("modelId"),
                 "name": "Google WiFi",
             }
             units.append(wifi)


### PR DESCRIPTION
My Linksys Smart Wi-Fi router is falsely recognized as a google wifi. Although I don't mind, this causes a crash in scan.py when trying to `get` the modelId. 
This patch handles this by checking for a `None` before trying a `get`.
